### PR TITLE
feat: implement SPLaSK tracking script

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import { locales, routing } from "@/lib/i18n";
 import { getPayload } from "payload";
 import { FSM, FSP } from "@/lib/decorator";
 import { notFound } from "next/navigation";
+import Script from "next/script";
 
 const inter = Inter({ subsets: ["latin"] });
 const poppins = Poppins({
@@ -105,6 +106,20 @@ const Layout: FSP = async ({ children, params }) => {
             src="https://unpkg.com/@tinybirdco/flock.js"
             data-token={`${process.env.NEXT_PUBLIC_TINYBIRD_TOKEN}`}
           ></script>
+          <Script id="splask-matomo" strategy="beforeInteractive">
+            {`
+            var _paq = window._paq = window._paq || [];
+            _paq.push(['trackPageView']);
+            _paq.push(['enableLinkTracking']);
+            (function() {
+              var u = "//splask-analytics.jdn.gov.my/";
+              _paq.push(['setTrackerUrl', u + 'matomo.php']);
+              _paq.push(['setSiteId', '1385']);
+              var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+              g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+            })();
+          `}
+          </Script>
         </head>
       )}
       <SiteScript />


### PR DESCRIPTION
✅ What was implemented

    Integrated the official SPLaSK Matomo tracking script as provided by the team & Tuan Mielo.ais 

    Used Next.js next/script with strategy="beforeInteractive" to ensure the script loads before user interaction

    Wrapped inside a process.env.APP_ENV === "production" check so it only runs in production

Given SPLAsk code:
<script>
  var _paq = window._paq = window._paq || [];
  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
  _paq.push(['trackPageView']);
  _paq.push(['enableLinkTracking']);
  (function() {
    var u="//splask-analytics.jdn.gov.my/";
    _paq.push(['setTrackerUrl', u+'matomo.php']);
    _paq.push(['setSiteId', '1385']);
    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
  })();
</script>

prove:
<img width="1512" height="688" alt="Splask" src="https://github.com/user-attachments/assets/e268a804-7efe-4d25-90a2-5994d3f64079" />


code implementation location: /src/app/[locale]/layout.tsx 