### PR TITLE
fix(footer): update X/Twitter handle and fix noopener typo

### DIFF
--- a/src/app/[locale]/hubungi-kami/page-component.tsx
+++ b/src/app/[locale]/hubungi-kami/page-component.tsx
@@ -64,7 +64,7 @@ const ContactUs: FC<ContactUsProps> = async ({ data, locale }) => {
                         key={name}
                         href={href}
                         target="_blank"
-                        rel="noopenner noreferrer"
+                        rel="noopener noreferrer"
                         className={cn(
                           buttonVariants({ variant: "secondary-colour" }),
                           "rounded-full",
@@ -137,7 +137,7 @@ const ContactUs: FC<ContactUsProps> = async ({ data, locale }) => {
                           key={id}
                           href={link.url}
                           target="_blank"
-                          rel="noopenner noreferrer"
+                          rel="noopener noreferrer"
                           className="underline-font text-sm text-black-700 hover:text-foreground hover:underline max-md:col-span-2"
                         >
                           <div className="col-span-1 flex flex-none flex-col items-center gap-2 py-6 md:gap-3 xl:w-[100px]">

--- a/src/app/[locale]/siaran/[slug]/page-component.tsx
+++ b/src/app/[locale]/siaran/[slug]/page-component.tsx
@@ -83,7 +83,7 @@ const SiaranPage: FC<SiaranPageProps> = ({ data, locale }) => {
     //   name: "Facebook",
     //   href: "https://www.facebook.com/KementerianDigitalMalaysia/",
     // },
-    // { icon: Icon.X, name: "X", href: "https://x.com/KemDigitalMsia" },
+    // { icon: Icon.X, name: "X", href: "https://x.com/kemdigital_gov" },
   ];
   return (
     <main className="container grid auto-rows-auto grid-cols-1 py-12 md:grid-cols-12 lg:grid-cols-6 xl:grid-cols-4 print:mx-auto print:block print:w-full print:pb-12 print:pt-0">
@@ -144,7 +144,7 @@ const SiaranPage: FC<SiaranPageProps> = ({ data, locale }) => {
                     key={name}
                     href={href}
                     target="_blank"
-                    rel="noopenner noreferrer"
+                    rel="noopener noreferrer"
                     className="p-2"
                   >
                     <Icon className="size-4" />

--- a/src/components/home/quicklinks.tsx
+++ b/src/components/home/quicklinks.tsx
@@ -60,7 +60,7 @@ export default function Quicklinks({
                 <a
                   href="https://gamma.malaysia.gov.my/appdetails/553"
                   target="_blank"
-                  rel="noopenner noreferrer"
+                  rel="noopener noreferrer"
                   {...{ "splwpk-mobile-apps": "splwpk-mobile-apps" }}
                   className={cn(
                     buttonVariants({ variant: "secondary", size: "default" }),
@@ -120,7 +120,7 @@ export default function Quicklinks({
                     key={item.id}
                     href={link?.href[0].link?.url || ""}
                     target="_blank"
-                    rel="noopenner noreferrer"
+                    rel="noopener noreferrer"
                     {...(isMyMesyuarat && {
                       "splwpk-mobile-apps": "splwpk-mobile-apps",
                     })}

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -25,7 +25,7 @@ export const social_media = [
     name: "Facebook",
     href: "https://www.facebook.com/KementerianDigitalMalaysia/",
   },
-  { icon: <Icon.X />, name: "X", href: "https://x.com/KemDigitalMsia" },
+  { icon: <Icon.X />, name: "X", href: "https://x.com/kemdigital_gov" },
   {
     icon: <Icon.Instagram />,
     name: "Instagram",
@@ -92,7 +92,7 @@ export default function Footer({
                             key={id}
                             href={link.url}
                             target="_blank"
-                            rel="noopenner noreferrer"
+                            rel="noopener noreferrer"
                           >
                             {_social_media[social].icon}
                           </a>
@@ -123,7 +123,7 @@ export default function Footer({
                         key={name}
                         className={className.link}
                         target="_blank"
-                        rel="noopenner noreferrer"
+                        rel="noopener noreferrer"
                         href={href}
                       >
                         {name}


### PR DESCRIPTION
## Summarise the fix

Closes #95

**1. X/Twitter URL update**
- Updated the outdated handle `KemDigitalMsia` to the correct `kemdigital_gov` in the footer social media fallback array and a commented-out reference in the siaran page.

**2. `rel` attribute typo fix**
- Fixed `rel="noopenner noreferrer"` to `rel="noopener noreferrer"` across 4 files (7 occurrences). The misspelling `noopenner` means the `noopener` security directive was not being applied.

### Files changed

| File | Changes |
|------|---------|
| `src/components/layout/footer.tsx` | URL fix + 2x noopener typo |
| `src/components/home/quicklinks.tsx` | 2x noopener typo |
| `src/app/[locale]/hubungi-kami/page-component.tsx` | 2x noopener typo |
| `src/app/[locale]/siaran/[slug]/page-component.tsx` | 1x noopener typo + commented-out URL fix |

### Note on CMS data
The live social media links are rendered from Payload CMS (`siteInfo.social_media`). The hardcoded `social_media` array in `footer.tsx` serves as a fallback. The actual CMS record may also need updating via the admin panel.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have verified no remaining instances of `noopenner` in the codebase
- [x] I have verified no remaining instances of the old Twitter handle in component code
- [x] My changes generate no new warnings